### PR TITLE
fix: media player assets not working in Safari

### DIFF
--- a/js/epub-fetch/discover_content_type.js
+++ b/js/epub-fetch/discover_content_type.js
@@ -30,7 +30,9 @@ define(['jquery', 'URIjs'], function ($, URI) {
             opf: 'application/oebps-package+xml',
             png: 'image/png',
             svg: 'image/svg+xml',
-            xhtml: 'application/xhtml+xml'
+            xhtml: 'application/xhtml+xml',
+            mp3: "audio/mpeg",
+            mp4: "video/mp4"
         };
 
         this.identifyContentTypeFromFileName = function(contentUrl) {


### PR DESCRIPTION
Safari explicitly requires a content type for the audio element src to be defined when using blob URL.